### PR TITLE
Exit Ruby process to release memory resource

### DIFF
--- a/lib/litestream/commands.rb
+++ b/lib/litestream/commands.rb
@@ -86,7 +86,12 @@ module Litestream
 
       command = [executable, "replicate", *args]
       puts command.inspect
-      system(*command)
+
+      # To release the resources of the Ruby process, just fork and exit.
+      # The forked process executes litestream and replaces itself.
+      if fork.nil?
+        exec(*command)
+      end
     end
   end
 end


### PR DESCRIPTION
## Background

Currently, this gem launches Litestream as a subprocess, and the original Ruby process waits for the termination of the subprocess.

I am using this gem in a Rails project. Since Rails projects generally use about 200 to 300MB of RAM, keeping the Ruby process alive means continuously monopolizing the server's RAM resources unnecessarily.

## Proposal

Terminate the Ruby process and keep only the Litestream process alive.

## Implementation

Use `fork` and `exec` instead of `system`.

- Original process: continue rest of program after fork. (currently, just exit immediately after fork.)
- Forked process: call `exec` and replace itself with new Litestream process