### PR TITLE
Generate config file with support for multiple databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /exe/*/litestream
 test/dummy/log/test.log
 .DS_Store
+/test/**/*.sqlite3

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The gem streamlines the configuration process by providing a default configurati
 dbs:
   - path: $LITESTREAM_DATABASE_PATH
     replicas:
-      - url: $LITESTREAM_REPLICA_URL
+      - url: $LITESTREAM_REPLICA_BUCKET
         access-key-id: $LITESTREAM_ACCESS_KEY_ID
         secret-access-key: $LITESTREAM_SECRET_ACCESS_KEY
 ```
@@ -66,7 +66,7 @@ The gem also provides a default initializer file at `config/initializers/litestr
 litestream_credentials = Rails.application.credentials.litestream
 Litestream.configure do |config|
   config.database_path = ActiveRecord::Base.connection_db_config.database
-  config.replica_url = litestream_credentials.replica_url
+  config.replica_bucket = litestream_credentials.replica_bucket
   config.replica_key_id = litestream_credentials.replica_key_id
   config.replica_access_key = litestream_credentials.replica_access_key
 end
@@ -113,7 +113,7 @@ Once you have a MinIO server running, you can create a bucket for Litestream to 
 ```ruby
 Litestream.configure do |config|
   config.database_path = ActiveRecord::Base.connection_db_config.database
-  config.replica_url = "s3://mybkt.localhost:9000/"
+  config.replica_bucket = "s3://mybkt.localhost:9000/"
   config.replica_key_id = "minioadmin"
   config.replica_access_key = "minioadmin"
 end

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ LITESTREAM_INSTALL_DIR=.bin
 
 You configure the Litestream executable through the [`config/litestream.yml` file](https://litestream.io/reference/config/), which is a standard Litestream configuration file as if Litestream was running in a traditional installation.
 
-The gem streamlines the configuration process by providing a default configuration file for you. This configuration file will backup one application database to one replication bucket. In order to ensure that no secrets are stored in plain-text in your repository, this configuration file leverages Litestream's support for environment variables. The default configuration file looks like this:
+The gem streamlines the configuration process by providing a default configuration file for you. This configuration file will backup all SQLite databases defined in your `config/database.yml` file to one replication bucket. In order to ensure that no secrets are stored in plain-text in your repository, this configuration file leverages Litestream's support for environment variables. The default configuration file looks like this if you only have one SQLite database:
 
 ```yaml
 dbs:

--- a/lib/litestream.rb
+++ b/lib/litestream.rb
@@ -11,7 +11,7 @@ module Litestream
   end
 
   class Configuration
-    attr_accessor :database_path, :replica_url, :replica_key_id, :replica_access_key
+    attr_accessor :database_path, :replica_bucket, :replica_key_id, :replica_access_key
 
     def initialize
       @mailer_sender = "donotreply@example.com"

--- a/lib/litestream/commands.rb
+++ b/lib/litestream/commands.rb
@@ -74,7 +74,6 @@ module Litestream
 
     def self.replicate(argv = {})
       if Litestream.configuration
-        ENV["LITESTREAM_DATABASE_PATH"] = Litestream.configuration.database_path
         ENV["LITESTREAM_REPLICA_BUCKET"] = Litestream.configuration.replica_bucket
         ENV["LITESTREAM_ACCESS_KEY_ID"] = Litestream.configuration.replica_key_id
         ENV["LITESTREAM_SECRET_ACCESS_KEY"] = Litestream.configuration.replica_access_key

--- a/lib/litestream/commands.rb
+++ b/lib/litestream/commands.rb
@@ -75,7 +75,7 @@ module Litestream
     def self.replicate(argv = {})
       if Litestream.configuration
         ENV["LITESTREAM_DATABASE_PATH"] = Litestream.configuration.database_path
-        ENV["LITESTREAM_REPLICA_URL"] = Litestream.configuration.replica_url
+        ENV["LITESTREAM_REPLICA_BUCKET"] = Litestream.configuration.replica_bucket
         ENV["LITESTREAM_ACCESS_KEY_ID"] = Litestream.configuration.replica_key_id
         ENV["LITESTREAM_SECRET_ACCESS_KEY"] = Litestream.configuration.replica_access_key
       end

--- a/lib/litestream/generators/litestream/install_generator.rb
+++ b/lib/litestream/generators/litestream/install_generator.rb
@@ -8,7 +8,7 @@ module Litestream
       source_root File.expand_path("templates", __dir__)
 
       def copy_config_file
-        template "config.yml", "config/litestream.yml"
+        template "config.yml.erb", "config/litestream.yml"
       end
 
       def copy_initializer_file
@@ -26,6 +26,16 @@ module Litestream
             PROCFILE
           end
         end
+      end
+
+      private
+
+      def production_sqlite_databases
+        ActiveRecord::Base
+          .configurations
+          .configs_for(env_name: "production", include_hidden: true)
+          .select { |config| ["sqlite3", "litedb"].include? config.adapter }
+          .map(&:database)
       end
     end
   end

--- a/lib/litestream/generators/litestream/templates/config.yml.erb
+++ b/lib/litestream/generators/litestream/templates/config.yml.erb
@@ -10,8 +10,12 @@
 #
 # For more details, see: https://litestream.io/reference/config/
 dbs:
-  - path: $LITESTREAM_DATABASE_PATH
+  <%- production_sqlite_databases.each do |database| -%>
+  - path: <%= database %>
     replicas:
-      - url: $LITESTREAM_REPLICA_URL
+      - type: s3
+        bucket: $LITESTREAM_REPLICA_BUCKET
+        path: <%= database %>
         access-key-id: $LITESTREAM_ACCESS_KEY_ID
         secret-access-key: $LITESTREAM_SECRET_ACCESS_KEY
+  <%- end -%>

--- a/lib/litestream/generators/litestream/templates/initializer.rb
+++ b/lib/litestream/generators/litestream/templates/initializer.rb
@@ -17,14 +17,18 @@ Litestream.configure do |config|
   # existing knowledge of the database path.
   # config.database_path = ActiveRecord::Base.connection_db_config.database
 
-  # Short-hand form of specifying a replica location.
-  # When using S3, a value will look like "s3://mybkt.litestream.io/db"
-  # Litestream also supports Azure Blog Storage, Backblaze B2, DigitalOcean Spaces,
+  # Replica-specific bucket location.
+  # This will be your bucket's URL without the `https://` prefix.
+  # For example, if you used DigitalOcean Spaces, your bucket URL could look like:
+  #   https://myapp.fra1.digitaloceanspaces.com
+  # And so you should set your `replica_bucket` to:
+  #   myapp.fra1.digitaloceanspaces.com
+  # Litestream supports Azure Blog Storage, Backblaze B2, DigitalOcean Spaces,
   # Scaleway Object Storage, Google Cloud Storage, Linode Object Storage, and
   # any SFTP server.
   # In this example, we are using Rails encrypted credentials to store the URL to
   # our storage provider bucket.
-  # config.replica_url = litestream_credentials.replica_url
+  # config.replica_bucket = litestream_credentials.replica_bucket
 
   # Replica-specific authentication key.
   # Litestream needs authentication credentials to access your storage provider bucket.

--- a/lib/litestream/generators/litestream/templates/initializer.rb
+++ b/lib/litestream/generators/litestream/templates/initializer.rb
@@ -1,21 +1,12 @@
 # Use this hook to configure the litestream-ruby gem.
 # All configuration options will be available as environment variables, e.g.
-# config.database_path becomes LITESTREAM_DATABASE_PATH
+# config.replica_bucket becomes LITESTREAM_REPLICA_BUCKET
 # This allows you to configure Litestream using Rails encrypted credentials,
 # or some other mechanism where the values are only avaialble at runtime.
 
 Litestream.configure do |config|
   # An example of using Rails encrypted credentials to configure Litestream.
   # litestream_credentials = Rails.application.credentials.litestream
-  #
-  # The absolute or relative path to a SQLite database file.
-  # Litestream will monitor this file for changes and replicate them to the
-  # any of the configured replicas specified for this database in the
-  # `litestream.yml` configuration file.
-  # When using SQLite as your database engine for ActiveRecord, you should always
-  # set this to the path of your SQLite database file. You can do so using Rails'
-  # existing knowledge of the database path.
-  # config.database_path = ActiveRecord::Base.connection_db_config.database
 
   # Replica-specific bucket location.
   # This will be your bucket's URL without the `https://` prefix.

--- a/lib/tasks/litestream_tasks.rake
+++ b/lib/tasks/litestream_tasks.rake
@@ -7,7 +7,7 @@ namespace :litestream do
     end
 
     puts "LITESTREAM_DATABASE_PATH=#{Litestream.configuration.database_path}"
-    puts "LITESTREAM_REPLICA_URL=#{Litestream.configuration.replica_url}"
+    puts "LITESTREAM_REPLICA_BUCKET=#{Litestream.configuration.replica_bucket}"
     puts "LITESTREAM_ACCESS_KEY_ID=#{Litestream.configuration.replica_key_id}"
     puts "LITESTREAM_SECRET_ACCESS_KEY=#{Litestream.configuration.replica_access_key}"
 

--- a/lib/tasks/litestream_tasks.rake
+++ b/lib/tasks/litestream_tasks.rake
@@ -6,7 +6,6 @@ namespace :litestream do
       next
     end
 
-    puts "LITESTREAM_DATABASE_PATH=#{Litestream.configuration.database_path}"
     puts "LITESTREAM_REPLICA_BUCKET=#{Litestream.configuration.replica_bucket}"
     puts "LITESTREAM_ACCESS_KEY_ID=#{Litestream.configuration.replica_key_id}"
     puts "LITESTREAM_SECRET_ACCESS_KEY=#{Litestream.configuration.replica_access_key}"

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -9,17 +9,42 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
 
-development:
+primary: &primary
   <<: *default
-  database: storage/development.sqlite3
+  database: storage/<%= ENV.fetch("RAILS_ENV", "development") %>.sqlite3
+
+queue: &queue
+  <<: *default
+  migrations_paths: db/queue_migrate
+  database: storage/queue.sqlite3
+
+errors: &errors
+  <<: *default
+  migrations_paths: db/errors_migrate
+  database: storage/errors.sqlite3
+
+development:
+  primary:
+    <<: *primary
+    database: storage/<%= `git branch --show-current`.chomp || 'development' %>.sqlite3
+  queue: *queue
+  errors: *errors
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
-  database: storage/test.sqlite3
+  primary:
+    <<: *primary
+    database: db/test.sqlite3
+  queue:
+    <<: *queue
+    database: db/queue.sqlite3
+  errors:
+    <<: *errors
+    database: db/errors.sqlite3
 
 production:
-  <<: *default
-  database: storage/production.sqlite3
+  primary: *primary
+  queue: *queue
+  errors: *errors

--- a/test/generators/test_install.rb
+++ b/test/generators/test_install.rb
@@ -19,6 +19,9 @@ class LitestreamGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     assert_file "config/litestream.yml" do |content|
+      assert_match "- path: storage/test.sqlite3", content
+      assert_match "- path: storage/queue.sqlite3", content
+      assert_match "- path: storage/errors.sqlite3", content
       assert_match "bucket: $LITESTREAM_REPLICA_BUCKET", content
       assert_match "access-key-id: $LITESTREAM_ACCESS_KEY_ID", content
       assert_match "secret-access-key: $LITESTREAM_SECRET_ACCESS_KEY", content

--- a/test/generators/test_install.rb
+++ b/test/generators/test_install.rb
@@ -20,14 +20,14 @@ class LitestreamGeneratorTest < Rails::Generators::TestCase
 
     assert_file "config/litestream.yml" do |content|
       assert_match "path: $LITESTREAM_DATABASE_PATH", content
-      assert_match "url: $LITESTREAM_REPLICA_URL", content
+      assert_match "bucket: $LITESTREAM_REPLICA_BUCKET", content
       assert_match "access-key-id: $LITESTREAM_ACCESS_KEY_ID", content
       assert_match "secret-access-key: $LITESTREAM_SECRET_ACCESS_KEY", content
     end
 
     assert_file "config/initializers/litestream.rb" do |content|
       assert_match "config.database_path = ActiveRecord::Base.connection_db_config.database", content
-      assert_match "config.replica_url = litestream_credentials.replica_url", content
+      assert_match "config.replica_bucket = litestream_credentials.replica_bucket", content
       assert_match "config.replica_key_id = litestream_credentials.replica_key_id", content
       assert_match "config.replica_access_key = litestream_credentials.replica_access_key", content
     end

--- a/test/generators/test_install.rb
+++ b/test/generators/test_install.rb
@@ -19,14 +19,12 @@ class LitestreamGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     assert_file "config/litestream.yml" do |content|
-      assert_match "path: $LITESTREAM_DATABASE_PATH", content
       assert_match "bucket: $LITESTREAM_REPLICA_BUCKET", content
       assert_match "access-key-id: $LITESTREAM_ACCESS_KEY_ID", content
       assert_match "secret-access-key: $LITESTREAM_SECRET_ACCESS_KEY", content
     end
 
     assert_file "config/initializers/litestream.rb" do |content|
-      assert_match "config.database_path = ActiveRecord::Base.connection_db_config.database", content
       assert_match "config.replica_bucket = litestream_credentials.replica_bucket", content
       assert_match "config.replica_key_id = litestream_credentials.replica_key_id", content
       assert_match "config.replica_access_key = litestream_credentials.replica_access_key", content

--- a/test/tasks/test_litestream_tasks.rb
+++ b/test/tasks/test_litestream_tasks.rb
@@ -32,7 +32,7 @@ class TestLitestreamTasks < ActiveSupport::TestCase
       Rake.application.invoke_task "litestream:env"
     end
 
-    assert_equal "LITESTREAM_DATABASE_PATH=path/to/database\nLITESTREAM_REPLICA_URL=\nLITESTREAM_ACCESS_KEY_ID=\nLITESTREAM_SECRET_ACCESS_KEY=\n", out
+    assert_equal "LITESTREAM_REPLICA_BUCKET=\nLITESTREAM_ACCESS_KEY_ID=\nLITESTREAM_SECRET_ACCESS_KEY=\n", out
     assert_equal "", err
   end
 


### PR DESCRIPTION
Resolves #1 

This evolves the gem setup process. Instead of relying on an ENV variable for the single database path, now the installation generator will introspect the host application's production database configuration and setup the Litestream configuration file to backup each of them, by default to the same replica bucket, but in different paths.