### PR TITLE
Remove a typo from upstream.rb

### DIFF
--- a/lib/litestream/upstream.rb
+++ b/lib/litestream/upstream.rb
@@ -1,5 +1,4 @@
 module Litestream
-  # constants describing the upstream tailwindcss project
   module Upstream
     VERSION = "v0.3.13"
 


### PR DESCRIPTION
Haven't noticed any tailwindcss projects in this gem. It's probably a typo :)