### PR TITLE
Make engine available in published gem pkg

### DIFF
--- a/litestream.gemspec
+++ b/litestream.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     "changelog_uri" => "https://github.com/fractaledmind/litestream-ruby/CHANGELOG.md"
   }
 
-  spec.files = Dir["lib/**/*", "LICENSE", "Rakefile", "README.md"]
+  spec.files = Dir["{app,config,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
   spec.bindir = "exe"
   spec.executables << "litestream"
 


### PR DESCRIPTION
When I upgrade to litestream 10.x, I expect to be able to mount the Litestream web ui in my Rails app when mounted in the routes file:

```rb
Rails.application.routes.draw do
  mount Litestream::Engine, at: "/litestream"
end
```

Instead, when I visit `/litestream`, I get `ActionController::RoutingError (No route matches [GET] "/litestream"):`

For this route to resolve in a host Rails application, the gem would need to provide `config/routes.rb` and controller(s) in `app/controllers`. Listing the files in my local installation of `litestream-ruby`, I see:

```
$ ls /path/to/.gem/ruby/3.3.0/gems/litestream-0.10.3-arm64-darwin 
LICENSE              README.md            exe
LICENSE-DEPENDENCIES Rakefile             lib
```
The `app` and `config` directories are missing.

The fix should be to add the missing directories to the gemspec so they can be included in the packaged gem.