### PR TITLE
Fix Litestream.replicate_process for systemd

### DIFF
--- a/lib/litestream.rb
+++ b/lib/litestream.rb
@@ -82,11 +82,11 @@ module Litestream
             pid, _name = value.strip.split(" ")
             info[:pid] = pid
           elsif line.start_with?("Active:")
-            _key, value = line.split(":")
-            value, _ago = value.split(";")
+            value, _ago = line.split(";")
             status, timestamp = value.split(" since ")
-            info[:started] = DateTime.strptime(timestamp.strip, "%Y-%m-%d %H:%M:%S %Z")
-            info[:status] = status.split("(").first.strip
+            info[:started] = DateTime.strptime(timestamp.strip, "%a %Y-%m-%d %H:%M:%S %Z")
+            status_match = status.match(%r{\((?<status>.*)\)})
+            info[:status] = status_match ? status_match[:status] : nil
           end
         end
       else

--- a/test/test_litestream.rb
+++ b/test/test_litestream.rb
@@ -6,4 +6,56 @@ class TestLitestream < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::Litestream::VERSION
   end
+
+  def test_replicate_process_systemd
+    stubbed_status = ["● litestream.service - Litestream",
+      "     Loaded: loaded (/lib/systemd/system/litestream.service; enabled; vendor preset: enabled)",
+      "     Active: active (running) since Tue 2023-07-25 13:49:43 UTC; 8 months 24 days ago",
+      "   Main PID: 1179656 (litestream)",
+      "      Tasks: 9 (limit: 1115)",
+      "     Memory: 22.9M",
+      "        CPU: 10h 49.843s",
+      "     CGroup: /system.slice/litestream.service",
+      "             └─1179656 /usr/bin/litestream replicate",
+      "",
+      "Warning: some journal files were not opened due to insufficient permissions."].join("\n")
+    Litestream.stub :`, stubbed_status do
+      info = Litestream.replicate_process
+
+      assert_equal info[:status], "running"
+      assert_equal info[:pid], "1179656"
+      assert_equal info[:started].class, DateTime
+    end
+  end
+
+  def test_replicate_process_ps
+    stubbed_ps_list = [
+      "40358 ttys008    0:01.11 ruby --yjit bin/rails litestream:replicate",
+      "40364 ttys008    0:00.07 /path/to/litestream-ruby/exe/architecture/litestream replicate --config /path/to/app/config/litestream.yml"
+    ].join("\n")
+
+    stubbed_ps_status = [
+      "STAT STARTED",
+      "S+   Mon Jul  1 11:10:58 2024"
+    ].join("\n")
+
+    stubbed_backticks = proc do |arg|
+      case arg
+      when "ps -a | grep litestream | grep replicate"
+        stubbed_ps_list
+      when %(ps -o "state,lstart" 40364)
+        stubbed_ps_status
+      else
+        ""
+      end
+    end
+
+    Litestream.stub :`, stubbed_backticks do
+      info = Litestream.replicate_process
+
+      assert_equal info[:status], "sleeping"
+      assert_equal info[:pid], "40364"
+      assert_equal info[:started].class, DateTime
+    end
+  end
 end


### PR DESCRIPTION
When I try to run `Litestream.replicate_process`, as in mounting the web ui, in production with `systemd`, I see the following error:

```sh
Date::Error: invalid date
    lib/litestream.rb:88:in `strptime'
    lib/litestream.rb:88:in `block in replicate_process'
    lib/litestream.rb:78:in `each'
    lib/litestream.rb:78:in `replicate_process'
```

The line splitting logic did not appear to work in my environment nor for the example output displayed in the comments of the `replicate_process` method.

This PR adds basic proof-of-concept tests for both variations of `replicate_process` and adds a fix for the DateTime parsing logic with systemd. In fixing that issue, I also encountered a bug in the status parsing logic for systemd which is also now addressed using a regex with a named capture group.