### PR TITLE
Support configuration of custom systemctl status command

### DIFF
--- a/lib/litestream.rb
+++ b/lib/litestream.rb
@@ -33,7 +33,7 @@ module Litestream
     end
   end
 
-  mattr_writer :username, :password, :queue, :replica_bucket, :replica_key_id, :replica_access_key
+  mattr_writer :username, :password, :queue, :replica_bucket, :replica_key_id, :replica_access_key, :systemctl_command
 
   class << self
     def verify!(database_path)
@@ -85,10 +85,14 @@ module Litestream
       @@replica_access_key || configuration.replica_access_key
     end
 
+    def systemctl_command
+      @@systemctl_command || "systemctl status litestream"
+    end
+
     def replicate_process
       info = {}
       if !`which systemctl`.empty?
-        systemctl_status = `systemctl status litestream`.chomp
+        systemctl_status = `#{Litestream.systemctl_command}`.chomp
         # ["● litestream.service - Litestream",
         #  "     Loaded: loaded (/lib/systemd/system/litestream.service; enabled; vendor preset: enabled)",
         #  "     Active: active (running) since Tue 2023-07-25 13:49:43 UTC; 8 months 24 days ago",

--- a/test/test_litestream.rb
+++ b/test/test_litestream.rb
@@ -3,6 +3,10 @@
 require "test_helper"
 
 class TestLitestream < Minitest::Test
+  def teardown
+    Litestream.systemctl_command = nil
+  end
+
   def test_that_it_has_a_version_number
     refute_nil ::Litestream::VERSION
   end
@@ -19,6 +23,29 @@ class TestLitestream < Minitest::Test
       "             └─1179656 /usr/bin/litestream replicate",
       "",
       "Warning: some journal files were not opened due to insufficient permissions."].join("\n")
+    Litestream.stub :`, stubbed_status do
+      info = Litestream.replicate_process
+
+      assert_equal info[:status], "running"
+      assert_equal info[:pid], "1179656"
+      assert_equal info[:started].class, DateTime
+    end
+  end
+
+  def test_replicate_process_systemd_custom_command
+    stubbed_status = ["● myapp-litestream.service - Litestream",
+      "     Loaded: loaded (/lib/systemd/system/litestream.service; enabled; vendor preset: enabled)",
+      "     Active: active (running) since Tue 2023-07-25 13:49:43 UTC; 8 months 24 days ago",
+      "   Main PID: 1179656 (litestream)",
+      "      Tasks: 9 (limit: 1115)",
+      "     Memory: 22.9M",
+      "        CPU: 10h 49.843s",
+      "     CGroup: /system.slice/litestream.service",
+      "             └─1179656 /usr/bin/litestream replicate",
+      "",
+      "Warning: some journal files were not opened due to insufficient permissions."].join("\n")
+    Litestream.systemctl_command = "systemctl --user status myapp-litestream.service"
+
     Litestream.stub :`, stubbed_status do
       info = Litestream.replicate_process
 


### PR DESCRIPTION
I use systemd in production with litestream-ruby (on Hatchbox). When I check the status of Litestream in the litestream-ruby web ui, the status reported is "not running".

![Screenshot 2024-09-04 at 7 34 18 AM](https://github.com/user-attachments/assets/4c683ac0-609d-40c1-ae8d-d95248385c0d)

The reason this is happening is that built-in command for litestream-ruby to check the status of the litestream process returns an error message:

```
$ systemctl status litestream
Unit litestream.service could not be found.
```

On Hatchbox, I need to use a slightly different command to check the status:

```
$ systemctl --user status myapp-litestream.service
● myapp-litestream.service - myapp-litestream
     Loaded: loaded (/home/deploy/.config/systemd/user/myapp-litestream.service; enabled; vendor preset: enabled)
     Active: active (running) since Wed YYYY-MM-DD HH:MM:SS UTC; 20min ago
   Main PID: <PID> (ruby)
   # ...
```

To address this, the approach I had in mind is to make the systemctl status command configurable. 

