### PR TITLE
Add wal command

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ name  generation        lag     start                 end
 s3    a295b16a796689f3  -156ms  2024-04-17T00:01:19Z  2024-04-17T00:01:19Z
 ```
 
-Finally, you can list the snapshots available for a database:
+You can list the snapshots available for a database:
 
 ```shell
 bin/rails litestream:snapshots -- --database=storage/production.sqlite3
@@ -379,6 +379,19 @@ This command lists snapshots available for that specified database:
 ```
 replica  generation        index  size     created
 s3       a295b16a796689f3  1      4645465  2024-04-17T00:01:19Z
+```
+
+Finally, you can list the wal files available for a database:
+
+```shell
+bin/rails litestream:wal -- --database=storage/production.sqlite3
+```
+
+This command lists wal files available for that specified database:
+
+```
+replica  generation        index  offset    size     created
+s3       a295b16a796689f3  1      0         2036     2024-04-17T00:01:19Z
 ```
 
 ### Running commands from Ruby
@@ -406,7 +419,14 @@ Litestream::Commands.snapshots('storage/production.sqlite3')
 # => [{"replica"=>"s3", "generation"=>"5f4341bc3d22d615", "index"=>"0", "size"=>"4645465", "created"=>"2024-04-17T19:48:09Z"}]
 ```
 
-You can also restore a database programatically using the `Litestream::Commands.restore` method, which returns the path to the restored database:
+The `Litestream::Commands.wal` method returns an array of hashes with the "replica", "generation", "index", "offset","size", and "created" keys for each wal:
+
+```ruby
+Litestream::Commands.wal('storage/production.sqlite3')
+# => [{"replica"=>"s3", "generation"=>"5f4341bc3d22d615", "index"=>"0",  "offset"=>"0", "size"=>"2036", "created"=>"2024-04-17T19:48:09Z"}]
+```
+
+You can also restore a database programmatically using the `Litestream::Commands.restore` method, which returns the path to the restored database:
 
 ```ruby
 Litestream::Commands.restore('storage/production.sqlite3')

--- a/lib/litestream/commands.rb
+++ b/lib/litestream/commands.rb
@@ -104,6 +104,12 @@ module Litestream
         execute("snapshots", argv, database, async: async, tabled_output: true)
       end
 
+      def wal(database, async: false, **argv)
+        raise DatabaseRequiredException, "database argument is required for wal command, e.g. litestream:wal -- --database=path/to/database.sqlite" if database.nil?
+
+        execute("wal", argv, database, async: async, tabled_output: true)
+      end
+
       private
 
       def execute(command, argv = {}, database = nil, async: false, tabled_output: false)

--- a/lib/tasks/litestream_tasks.rake
+++ b/lib/tasks/litestream_tasks.rake
@@ -75,4 +75,18 @@ namespace :litestream do
 
     Litestream::Commands.snapshots(database, async: true, **options)
   end
+
+  desc "List all wal files for a database or replica, for example `rake litestream:wal -- -database=storage/production.sqlite3`"
+  task wal: :environment do
+    options = {}
+    if (separator_index = ARGV.index("--"))
+      ARGV.slice(separator_index + 1, ARGV.length)
+        .map { |pair| pair.split("=") }
+        .each { |opt| options[opt[0]] = opt[1] || nil }
+    end
+    database = options.delete("--database") || options.delete("-database")
+    options.symbolize_keys!
+
+    Litestream::Commands.wal(database, async: true, **options)
+  end
 end


### PR DESCRIPTION
After instalIing litestream-ruby and trying several configuration changes, I needed to check the wal files presence in my bucket. 

As this gem implements all Litestream commands but `wal`, this PR implements the wal command.

