### PR TITLE
Fix litestream showing as "not running" in Docker

### DIFF
--- a/lib/litestream.rb
+++ b/lib/litestream.rb
@@ -115,7 +115,7 @@ module Litestream
           end
         end
       else
-        litestream_replicate_ps = `ps -a | grep litestream | grep replicate`.chomp
+        litestream_replicate_ps = `ps -ax | grep litestream | grep replicate`.chomp
         litestream_replicate_ps.split("\n").each do |line|
           next unless line.include?("litestream replicate")
           pid, * = line.split(" ")

--- a/test/test_litestream.rb
+++ b/test/test_litestream.rb
@@ -41,7 +41,7 @@ class TestLitestream < Minitest::Test
 
     stubbed_backticks = proc do |arg|
       case arg
-      when "ps -a | grep litestream | grep replicate"
+      when "ps -ax | grep litestream | grep replicate"
         stubbed_ps_list
       when %(ps -o "state,lstart" 40364)
         stubbed_ps_status


### PR DESCRIPTION
When deploying litestream-ruby via Kamal and Docker, the dashboard shows the process as not running. Using the "x" option for "ps" seems to solve this.

As per ps man page:

> Lift the BSD-style "must have a tty" restriction, which imposed upon the set of all processes when some BSD-style
       (without "-") options are used or  when  the personality  setting  is  BSD-like.   The  set processes  selected  in this manner is in addition to the set of processes selected by other means.
> 
> An alternate description is that this option causes ps list all processes owned by you (same EUID as ps), or list all processes when used together with the a option.


Resolves: https://github.com/fractaledmind/litestream-ruby/issues/43