### PR TITLE
Remove docs about deprecated`Litestream::Command.verify` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,13 +434,6 @@ Litestream::Commands.restore('storage/production.sqlite3')
 # => "storage/production-20240418090048.sqlite3"
 ```
 
-Finally, you can verify the integrity of a restored database using the `Litestream::Commands.verify` method, which returns a hash with the "size" and "tables" keys for the original and restored databases:
-
-```ruby
-Litestream::Commands.verify('storage/production.sqlite3')
-# => {"size"=>{"original"=>21688320, "restored"=>21688320}, "tables"=>{"original"=>9, "restored"=>9}}
-```
-
 You _can_ start the replication process using the `Litestream::Commands.replicate` method, but this is not recommended. The replication process should be managed by Litestream itself, and you should not need to manually start it.
 
 ### Running commands from CLI


### PR DESCRIPTION
The `README` still mention the `verify` command that has been removed in https://github.com/fractaledmind/litestream-ruby/pull/28. 

I didn't replace it with the new sentinel method command as it's already pretty well covered [in its own section](https://github.com/fractaledmind/litestream-ruby?tab=readme-ov-file#verification).