### PR TITLE
Adds ability to configure default config path

### DIFF
--- a/lib/litestream.rb
+++ b/lib/litestream.rb
@@ -33,7 +33,8 @@ module Litestream
     end
   end
 
-  mattr_writer :username, :password, :queue, :replica_bucket, :replica_key_id, :replica_access_key, :systemctl_command
+  mattr_writer :username, :password, :queue, :replica_bucket, :replica_key_id, :replica_access_key, :systemctl_command,
+    :config_path
 
   class << self
     def verify!(database_path)
@@ -87,6 +88,10 @@ module Litestream
 
     def systemctl_command
       @@systemctl_command || "systemctl status litestream"
+    end
+
+    def config_path
+      @@config_path || Rails.root.join("config", "litestream.yml")
     end
 
     def replicate_process

--- a/lib/litestream/commands.rb
+++ b/lib/litestream/commands.rb
@@ -129,7 +129,7 @@ module Litestream
         ENV["LITESTREAM_SECRET_ACCESS_KEY"] ||= Litestream.replica_access_key
 
         args = {
-          "--config" => Rails.root.join("config", "litestream.yml").to_s
+          "--config" => Litestream.config_path.to_s
         }.merge(argv.stringify_keys).to_a.flatten.compact
         cmd = [executable, command, *args, database].compact
         puts cmd.inspect if ENV["DEBUG"]

--- a/test/litestream/test_commands.rb
+++ b/test/litestream/test_commands.rb
@@ -15,6 +15,7 @@ class TestCommands < ActiveSupport::TestCase
     Litestream.replica_bucket = ENV["LITESTREAM_REPLICA_BUCKET"] = nil
     Litestream.replica_key_id = ENV["LITESTREAM_ACCESS_KEY_ID"] = nil
     Litestream.replica_access_key = ENV["LITESTREAM_SECRET_ACCESS_KEY"] = nil
+    Litestream.config_path = nil
   end
 
   class TestReplicateCommand < TestCommands
@@ -421,6 +422,22 @@ class TestCommands < ActiveSupport::TestCase
       assert_equal "original_bkt", ENV["LITESTREAM_REPLICA_BUCKET"]
       assert_equal "original_key", ENV["LITESTREAM_ACCESS_KEY_ID"]
       assert_equal "original_access", ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+    end
+
+    def test_databases_read_from_custom_configured_litestream_config_path
+      Litestream.config_path = "dummy/config/litestream/production.yml"
+
+      stub = proc do |cmd, _async|
+        _executable, _command, *argv = cmd
+
+        assert_equal 2, argv.size
+        assert_equal "--config", argv[0]
+        assert_match Regexp.new("dummy/config/litestream/production.yml"), argv[1]
+      end
+
+      Litestream::Commands.stub :run, stub do
+        Litestream::Commands.databases
+      end
     end
   end
 


### PR DESCRIPTION
The Litestream Ruby config path defaults to `"config/litestream.yml"`. Some applications may wish to use a custom configuration path, say, one that is based on the Rails environment `"config/litestream/#{Rails.env}.yml"`

Though `Litestream::Commands` methods allow for passing a `--config` option for the config path, helper methods like `Litestream.verify!`, which wraps `Litestream::Commands.databases` and the Puma plugin, which wraps `Litestream::Commands.replicate`, do not.

This changeset adds the ability to configure an application-wide default for the litestream config path allows for use of features like `Litestream.verify!` and the Puma plugin without otherwise having to modify these features to accept the `--config` option.