### PR TITLE
Build the aarch64-linux gem

### DIFF
--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ["ruby", "x86_64-darwin", "arm64-darwin", "x86_64-linux", "arm64-linux"]
+        platform: ["ruby", "x86_64-darwin", "arm64-darwin", "x86_64-linux", "arm64-linux", "aarch64-linux"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,7 +232,7 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
-  arm64-darwin-21
+  arm64-darwin
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Supported platforms are:
 
 - arm64-darwin (macos-arm64)
 - x86_64-darwin (macos-x64)
+- aarch64-linux (linux-aarch64)
 - arm64-linux (linux-arm64)
 - x86_64-linux (linux-x64)
 
@@ -459,7 +460,7 @@ By default, if you install the gem and configure via `puma.rb` or `Procfile`, Li
 
 If you setup via `puma.rb`, then remove the conditional statement.
 
-If you setup via `Procfile`, you will need to update your `Procfile.dev` file. If you would like to test that your configuration is properly setup, you can manually add the `litestream:replicate` rake task to your `Procfile.dev` file. Just copy the `litestream` definition from the production `Procfile`. 
+If you setup via `Procfile`, you will need to update your `Procfile.dev` file. If you would like to test that your configuration is properly setup, you can manually add the `litestream:replicate` rake task to your `Procfile.dev` file. Just copy the `litestream` definition from the production `Procfile`.
 
 In order to have a replication bucket for Litestream to point to, you can use a Docker instance of [MinIO](https://min.io/). MinIO is an S3-compatible object storage server that can be run locally. You can run a MinIO server with the following command:
 

--- a/lib/litestream/upstream.rb
+++ b/lib/litestream/upstream.rb
@@ -4,6 +4,7 @@ module Litestream
 
     # rubygems platform name => upstream release filename
     NATIVE_PLATFORMS = {
+      "aarch64-linux" => "litestream-#{VERSION}-linux-arm64.tar.gz",
       "arm64-darwin" => "litestream-#{VERSION}-darwin-arm64.zip",
       "arm64-linux" => "litestream-#{VERSION}-linux-arm64.tar.gz",
       "x86_64-darwin" => "litestream-#{VERSION}-darwin-amd64.zip",

--- a/rakelib/package.rake
+++ b/rakelib/package.rake
@@ -26,6 +26,7 @@
 #  So the full set of gem files created will be:
 #
 #  - pkg/litestream-1.0.0.gem
+#  - pkg/litestream-1.0.0-aarch64-linux.gem
 #  - pkg/litestream-1.0.0-arm64-linux.gem
 #  - pkg/litestream-1.0.0-arm64-darwin.gem
 #  - pkg/litestream-1.0.0-x86_64-darwin.gem
@@ -38,7 +39,8 @@
 #  New rake tasks created:
 #
 #  - rake gem:ruby           # Build the ruby gem
-#  - rake gem:arm64-linux  # Build the aarch64-linux gem
+#  - rake gem:aarch64-linux  # Build the aarch64-linux gem
+#  - rake gem:arm64-linux    # Build the arm64-linux gem
 #  - rake gem:arm64-darwin   # Build the arm64-darwin gem
 #  - rake gem:x86_64-darwin  # Build the x86_64-darwin gem
 #  - rake gem:x86_64-linux   # Build the x86_64-linux gem


### PR DESCRIPTION
Build the aarch64-linux gem from litestream arm64-linux binaries.

Closes https://github.com/fractaledmind/litestream-ruby/issues/55

This is also needed to run litestream-ruby in Hetzner Ampere® shared vCPU (CAX series).