### PR TITLE
Support configuring replica region and endpoint

### DIFF
--- a/lib/litestream.rb
+++ b/lib/litestream.rb
@@ -33,7 +33,7 @@ module Litestream
     end
   end
 
-  mattr_writer :username, :password, :queue, :replica_bucket, :replica_key_id, :replica_access_key, :systemctl_command
+  mattr_writer :username, :password, :queue, :replica_bucket, :replica_region, :replica_endpoint, :replica_key_id, :replica_access_key, :systemctl_command
 
   class << self
     def verify!(database_path)
@@ -75,6 +75,14 @@ module Litestream
 
     def replica_bucket
       @@replica_bucket || configuration.replica_bucket
+    end
+
+    def replica_region
+      @@replica_region
+    end
+
+    def replica_endpoint
+      @@replica_endpoint
     end
 
     def replica_key_id

--- a/lib/litestream/commands.rb
+++ b/lib/litestream/commands.rb
@@ -125,6 +125,8 @@ module Litestream
 
       def prepare(command, argv = {}, database = nil)
         ENV["LITESTREAM_REPLICA_BUCKET"] ||= Litestream.replica_bucket
+        ENV["LITESTREAM_REPLICA_REGION"] ||= Litestream.replica_region
+        ENV["LITESTREAM_REPLICA_ENDPOINT"] ||= Litestream.replica_endpoint
         ENV["LITESTREAM_ACCESS_KEY_ID"] ||= Litestream.replica_key_id
         ENV["LITESTREAM_SECRET_ACCESS_KEY"] ||= Litestream.replica_access_key
 

--- a/lib/tasks/litestream_tasks.rake
+++ b/lib/tasks/litestream_tasks.rake
@@ -2,6 +2,8 @@ namespace :litestream do
   desc "Print the ENV variables needed for the Litestream config file"
   task env: :environment do
     puts "LITESTREAM_REPLICA_BUCKET=#{Litestream.replica_bucket}"
+    puts "LITESTREAM_REPLICA_REGION=#{Litestream.replica_region}"
+    puts "LITESTREAM_REPLICA_ENDPOINT=#{Litestream.replica_endpoint}"
     puts "LITESTREAM_ACCESS_KEY_ID=#{Litestream.replica_key_id}"
     puts "LITESTREAM_SECRET_ACCESS_KEY=#{Litestream.replica_access_key}"
 

--- a/test/tasks/test_litestream_tasks.rb
+++ b/test/tasks/test_litestream_tasks.rb
@@ -26,6 +26,8 @@ class TestLitestreamTasks < ActiveSupport::TestCase
 
       assert_equal <<~TXT, out
         LITESTREAM_REPLICA_BUCKET=
+        LITESTREAM_REPLICA_REGION=
+        LITESTREAM_REPLICA_ENDPOINT=
         LITESTREAM_ACCESS_KEY_ID=
         LITESTREAM_SECRET_ACCESS_KEY=
       TXT


### PR DESCRIPTION
I'm trying to setup replication using [Hetzner's Object Storage](https://docs.hetzner.com/storage/object-storage/overview/), but the default S3 options won't work.

LMK if there's another way around this and if this isn't necessary.