### PR TITLE
Fix replication process detection

### DIFF
--- a/lib/litestream.rb
+++ b/lib/litestream.rb
@@ -90,54 +90,7 @@ module Litestream
     end
 
     def replicate_process
-      info = {}
-      if !`which systemctl`.empty?
-        systemctl_status = `#{Litestream.systemctl_command}`.chomp
-        # ["● litestream.service - Litestream",
-        #  "     Loaded: loaded (/lib/systemd/system/litestream.service; enabled; vendor preset: enabled)",
-        #  "     Active: active (running) since Tue 2023-07-25 13:49:43 UTC; 8 months 24 days ago",
-        #  "   Main PID: 1179656 (litestream)",
-        #  "      Tasks: 9 (limit: 1115)",
-        #  "     Memory: 22.9M",
-        #  "        CPU: 10h 49.843s",
-        #  "     CGroup: /system.slice/litestream.service",
-        #  "             └─1179656 /usr/bin/litestream replicate",
-        #  "",
-        #  "Warning: some journal files were not opened due to insufficient permissions."]
-        systemctl_status.split("\n").each do |line|
-          line.strip!
-          if line.start_with?("Main PID:")
-            _key, value = line.split(":")
-            pid, _name = value.strip.split(" ")
-            info[:pid] = pid
-          elsif line.start_with?("Active:")
-            value, _ago = line.split(";")
-            status, timestamp = value.split(" since ")
-            info[:started] = DateTime.strptime(timestamp.strip, "%a %Y-%m-%d %H:%M:%S %Z")
-            status_match = status.match(%r{\((?<status>.*)\)})
-            info[:status] = status_match ? status_match[:status] : nil
-          end
-        end
-      else
-        litestream_replicate_ps = `ps -ax | grep litestream | grep replicate`.chomp
-        litestream_replicate_ps.split("\n").each do |line|
-          next unless line.include?("litestream replicate")
-          pid, * = line.split(" ")
-          info[:pid] = pid
-          state, _, lstart = `ps -o "state,lstart" #{pid}`.chomp.split("\n").last.partition(/\s+/)
-
-          info[:status] = case state[0]
-          when "I" then "idle"
-          when "R" then "running"
-          when "S" then "sleeping"
-          when "T" then "stopped"
-          when "U" then "uninterruptible"
-          when "Z" then "zombie"
-          end
-          info[:started] = DateTime.strptime(lstart.strip, "%a %b %d %H:%M:%S %Y")
-        end
-      end
-      info
+      systemctl_info || process_info || {}
     end
 
     def databases
@@ -156,6 +109,70 @@ module Litestream
           generation.slice("generation", "name", "lag", "start", "end", "snapshots")
         end
       end
+    end
+
+    private
+
+    def systemctl_info
+      return if `which systemctl`.empty?
+
+      systemctl_output = `#{Litestream.systemctl_command}`
+      systemctl_exit_code = $?.exitstatus
+      return unless systemctl_exit_code.zero?
+
+      # ["● litestream.service - Litestream",
+      #  "     Loaded: loaded (/lib/systemd/system/litestream.service; enabled; vendor preset: enabled)",
+      #  "     Active: active (running) since Tue 2023-07-25 13:49:43 UTC; 8 months 24 days ago",
+      #  "   Main PID: 1179656 (litestream)",
+      #  "      Tasks: 9 (limit: 1115)",
+      #  "     Memory: 22.9M",
+      #  "        CPU: 10h 49.843s",
+      #  "     CGroup: /system.slice/litestream.service",
+      #  "             └─1179656 /usr/bin/litestream replicate",
+      #  "",
+      #  "Warning: some journal files were not opened due to insufficient permissions."]
+
+      info = {}
+      systemctl_output.chomp.split("\n").each do |line|
+        line.strip!
+        if line.start_with?("Main PID:")
+          _key, value = line.split(":")
+          pid, _name = value.strip.split(" ")
+          info[:pid] = pid
+        elsif line.start_with?("Active:")
+          value, _ago = line.split(";")
+          status, timestamp = value.split(" since ")
+          info[:started] = DateTime.strptime(timestamp.strip, "%a %Y-%m-%d %H:%M:%S %Z")
+          status_match = status.match(%r{\((?<status>.*)\)})
+          info[:status] = status_match ? status_match[:status] : nil
+        end
+      end
+      info
+    end
+
+    def process_info
+      litestream_replicate_ps = `ps -ax | grep litestream | grep replicate`
+      systemctl_exit_code = $?.exitstatus
+      return unless systemctl_exit_code.zero?
+
+      info = {}
+      litestream_replicate_ps.chomp.split("\n").each do |line|
+        next unless line.include?("litestream replicate")
+        pid, * = line.split(" ")
+        info[:pid] = pid
+        state, _, lstart = `ps -o "state,lstart" #{pid}`.chomp.split("\n").last.partition(/\s+/)
+
+        info[:status] = case state[0]
+        when "I" then "idle"
+        when "R" then "running"
+        when "S" then "sleeping"
+        when "T" then "stopped"
+        when "U" then "uninterruptible"
+        when "Z" then "zombie"
+        end
+        info[:started] = DateTime.strptime(lstart.strip, "%a %b %d %H:%M:%S %Y")
+      end
+      info
     end
   end
 end

--- a/lib/litestream.rb
+++ b/lib/litestream.rb
@@ -152,12 +152,13 @@ module Litestream
 
     def process_info
       litestream_replicate_ps = `ps -ax | grep litestream | grep replicate`
-      systemctl_exit_code = $?.exitstatus
-      return unless systemctl_exit_code.zero?
+      exit_code = $?.exitstatus
+      return unless exit_code.zero?
 
       info = {}
       litestream_replicate_ps.chomp.split("\n").each do |line|
         next unless line.include?("litestream replicate")
+
         pid, * = line.split(" ")
         info[:pid] = pid
         state, _, lstart = `ps -o "state,lstart" #{pid}`.chomp.split("\n").last.partition(/\s+/)


### PR DESCRIPTION
This fixes an issue where running litestream processes would not be detected if systemctl is installed but litestream doesn't actually run via systemctl. As was the case on my machine :upside_down_face: 

![image](https://github.com/user-attachments/assets/65284f6d-a6d6-450d-a5e7-bc51840b83dc)


The fix is to return early if `Litestream.systemctl_command` returns with an error code. Then we try detecting any litestream process. If that fails we fall back to an empty hash.  

