### PR TITLE
Remove locale check

### DIFF
--- a/app/controllers/litestream/application_controller.rb
+++ b/app/controllers/litestream/application_controller.rb
@@ -1,19 +1,12 @@
 module Litestream
   class ApplicationController < ActionController::Base
     protect_from_forgery with: :exception
-    around_action :force_english_locale!
 
     if Litestream.password
       http_basic_authenticate_with(
         name: Litestream.username,
         password: Litestream.password
       )
-    end
-
-    private
-
-    def force_english_locale!(&action)
-      I18n.with_locale(:en, &action)
     end
   end
 end


### PR DESCRIPTION
I have a client project where we have this configuration: 

```ruby
I18n.available_locales = [ :de ]

# Set default locale to something other than :en
I18n.default_locale = :de
```

Notice, there's no `:en` there. Opening `/litestream` in this project results in an error .
```
I18n::InvalidLocale (:en is not a valid locale):
i18n (1.14.7) lib/i18n.rb:382:in `enforce_available_locales!'
```

Removing `enforce_available_locales!` fixes the issue (as does adding `:en` to the list of available locales, of course). 

Now, I'm not sure what the reasoning was behind initially enforcing the English locale. None of the views contain localized strings (as far as I can tell?) so forcing a locale doesn't seem to have any impact :thinking: 
