### PR TITLE
fix: Improve compatibility with Alpine Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,11 @@ time=YYYY-MM-DDTHH:MM:SS level=INFO msg="initialized db" path=/path/to/your/app/
 time=YYYY-MM-DDTHH:MM:SS level=INFO msg="replicating to" name=s3 type=s3 sync-interval=1s bucket=mybkt path="" region=us-east-1 endpoint=http://localhost:9000
 ```
 
+### Troubleshooting
+
+Some version of Linux don't install `ps`, you may need to install it in order to
+leverage the Rails engine.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/litestream.rb
+++ b/lib/litestream.rb
@@ -164,7 +164,7 @@ module Litestream
     end
 
     def process_info
-      litestream_replicate_ps = `ps -ax | grep litestream | grep replicate`
+      litestream_replicate_ps = `ps -ef | grep litestream | grep replicate`
       exit_code = $?.exitstatus
       return unless exit_code.zero?
 

--- a/test/test_litestream.rb
+++ b/test/test_litestream.rb
@@ -68,7 +68,7 @@ class TestLitestream < Minitest::Test
 
     stubbed_backticks = proc do |arg|
       case arg
-      when "ps -ax | grep litestream | grep replicate"
+      when "ps -ef | grep litestream | grep replicate"
         stubbed_ps_list
       when %(ps -o "state,lstart" 40364)
         stubbed_ps_status


### PR DESCRIPTION
Alpine's `ps` doesn't support the `-x` command. SO suggests `-ef` is more than sufficient as a replacement.