### PR TITLE
Add age encryption support for database backups

### DIFF
--- a/lib/litestream.rb
+++ b/lib/litestream.rb
@@ -27,13 +27,13 @@ module Litestream
   end
 
   class Configuration
-    attr_accessor :replica_bucket, :replica_key_id, :replica_access_key
+    attr_accessor :replica_bucket, :replica_key_id, :replica_access_key, :age_recipient, :age_secret_key
 
     def initialize
     end
   end
 
-  mattr_writer :username, :password, :queue, :replica_bucket, :replica_region, :replica_endpoint, :replica_key_id, :replica_access_key, :systemctl_command, :config_path
+  mattr_writer :username, :password, :queue, :replica_bucket, :replica_region, :replica_endpoint, :replica_key_id, :replica_access_key, :age_recipient, :age_secret_key, :systemctl_command, :config_path
   mattr_accessor :base_controller_class, default: "::ApplicationController"
 
   class << self
@@ -92,6 +92,14 @@ module Litestream
 
     def replica_access_key
       @@replica_access_key || configuration.replica_access_key
+    end
+
+    def age_recipient
+      @@age_recipient || configuration.age_recipient
+    end
+
+    def age_secret_key
+      @@age_secret_key || configuration.age_secret_key
     end
 
     def systemctl_command

--- a/lib/litestream/commands.rb
+++ b/lib/litestream/commands.rb
@@ -151,6 +151,8 @@ module Litestream
         ENV["LITESTREAM_REPLICA_ENDPOINT"] ||= Litestream.replica_endpoint
         ENV["LITESTREAM_ACCESS_KEY_ID"] ||= Litestream.replica_key_id
         ENV["LITESTREAM_SECRET_ACCESS_KEY"] ||= Litestream.replica_access_key
+        ENV["LITESTREAM_AGE_RECIPIENT"] ||= Litestream.age_recipient
+        ENV["LITESTREAM_AGE_SECRET_KEY"] ||= Litestream.age_secret_key
 
         args = {
           "--config" => Litestream.config_path.to_s

--- a/lib/litestream/generators/litestream/templates/config.yml.erb
+++ b/lib/litestream/generators/litestream/templates/config.yml.erb
@@ -9,6 +9,15 @@
 # `replicate` command.
 #
 # For more details, see: https://litestream.io/reference/config/
+
+# Uncomment to enable age encryption for all databases
+# See https://litestream.io/reference/config/#age-encryption
+# age:
+#   recipients:
+#     - $LITESTREAM_AGE_RECIPIENT
+#   identities:
+#     - $LITESTREAM_AGE_SECRET_KEY
+
 dbs:
   <%- production_sqlite_databases.each do |database| -%>
   - path: <%= database %>

--- a/lib/litestream/generators/litestream/templates/initializer.rb
+++ b/lib/litestream/generators/litestream/templates/initializer.rb
@@ -25,11 +25,19 @@ Rails.application.configure do
   # Replica-specific secret key. Litestream needs authentication credentials to access your storage provider bucket.
   # config.litestream.replica_access_key = litestream_credentials&.replica_access_key
   #
-  # Replica-specific region. Set the bucket’s region. Only used for AWS S3 & Backblaze B2.
+  # Replica-specific region. Set the bucket's region. Only used for AWS S3 & Backblaze B2.
   # config.litestream.replica_region = "us-east-1"
   #
   # Replica-specific endpoint. Set the endpoint URL of the S3-compatible service. Only required for non-AWS services.
   # config.litestream.replica_endpoint = "endpoint.your-objectstorage.com"
+  #
+  # Age encryption recipient public key. Used to encrypt the database backup.
+  # Uncomment the age: section in config/litestream.yml to enable age encryption.
+  # See https://litestream.io/reference/config/#age-encryption for more details.
+  # config.litestream.age_recipient = litestream_credentials&.age_recipient
+  #
+  # Age encryption secret key (identity). Used to decrypt the database backup during restore.
+  # config.litestream.age_secret_key = litestream_credentials&.age_secret_key
 
   # Configure the default Litestream config path
   # config.config_path = Rails.root.join("config", "litestream.yml")

--- a/lib/tasks/litestream_tasks.rake
+++ b/lib/tasks/litestream_tasks.rake
@@ -1,11 +1,13 @@
 namespace :litestream do
-  desc "Print the ENV variables needed for the Litestream config file"
+  desc 'Print the ENV variables needed for the Litestream config file'
   task env: :environment do
     puts "LITESTREAM_REPLICA_BUCKET=#{Litestream.replica_bucket}"
     puts "LITESTREAM_REPLICA_REGION=#{Litestream.replica_region}"
     puts "LITESTREAM_REPLICA_ENDPOINT=#{Litestream.replica_endpoint}"
     puts "LITESTREAM_ACCESS_KEY_ID=#{Litestream.replica_key_id}"
     puts "LITESTREAM_SECRET_ACCESS_KEY=#{Litestream.replica_access_key}"
+    puts "LITESTREAM_AGE_RECIPIENT=#{Litestream.age_recipient}"
+    puts "LITESTREAM_AGE_SECRET_KEY=#{Litestream.age_secret_key}"
 
     true
   end
@@ -17,7 +19,7 @@ namespace :litestream do
     Litestream::Commands.replicate(**options)
   end
 
-  desc "Restore a SQLite database from a Litestream replica, for example `rake litestream:restore -- -database=storage/production.sqlite3`"
+  desc 'Restore a SQLite database from a Litestream replica, for example `rake litestream:restore -- -database=storage/production.sqlite3`'
   task restore: :environment do
     options = parse_argv_options
     database = options.delete(:"--database") || options.delete(:"-database")
@@ -25,14 +27,14 @@ namespace :litestream do
     puts Litestream::Commands.restore(database, **options)
   end
 
-  desc "List all databases and associated replicas in the config file, for example `rake litestream:databases -- -no-expand-env`"
+  desc 'List all databases and associated replicas in the config file, for example `rake litestream:databases -- -no-expand-env`'
   task databases: :environment do
     options = parse_argv_options
 
     puts Litestream::Commands::Output.format(Litestream::Commands.databases(**options))
   end
 
-  desc "List all generations for a database or replica, for example `rake litestream:generations -- -database=storage/production.sqlite3`"
+  desc 'List all generations for a database or replica, for example `rake litestream:generations -- -database=storage/production.sqlite3`'
   task generations: :environment do
     options = parse_argv_options
     database = options.delete(:"--database") || options.delete(:"-database")
@@ -40,7 +42,7 @@ namespace :litestream do
     puts Litestream::Commands::Output.format(Litestream::Commands.generations(database, **options))
   end
 
-  desc "List all snapshots for a database or replica, for example `rake litestream:snapshots -- -database=storage/production.sqlite3`"
+  desc 'List all snapshots for a database or replica, for example `rake litestream:snapshots -- -database=storage/production.sqlite3`'
   task snapshots: :environment do
     options = parse_argv_options
     database = options.delete(:"--database") || options.delete(:"-database")
@@ -48,7 +50,7 @@ namespace :litestream do
     puts Litestream::Commands::Output.format(Litestream::Commands.snapshots(database, **options))
   end
 
-  desc "List all wal files for a database or replica, for example `rake litestream:wal -- -database=storage/production.sqlite3`"
+  desc 'List all wal files for a database or replica, for example `rake litestream:wal -- -database=storage/production.sqlite3`'
   task wal: :environment do
     options = parse_argv_options
     database = options.delete(:"--database") || options.delete(:"-database")
@@ -62,10 +64,10 @@ namespace :litestream do
 
   def parse_argv_options
     options = {}
-    if (separator_index = ARGV.index("--"))
+    if (separator_index = ARGV.index('--'))
       ARGV.slice(separator_index + 1, ARGV.length)
-        .map { |pair| pair.split("=") }
-        .each { |opt| options[opt[0]] = opt[1] || nil }
+          .map { |pair| pair.split('=') }
+          .each { |opt| options[opt[0]] = opt[1] || nil }
     end
     options.symbolize_keys!
   end

--- a/test/litestream/test_commands.rb
+++ b/test/litestream/test_commands.rb
@@ -15,6 +15,8 @@ class TestCommands < ActiveSupport::TestCase
     Litestream.replica_bucket = ENV["LITESTREAM_REPLICA_BUCKET"] = nil
     Litestream.replica_key_id = ENV["LITESTREAM_ACCESS_KEY_ID"] = nil
     Litestream.replica_access_key = ENV["LITESTREAM_SECRET_ACCESS_KEY"] = nil
+    Litestream.age_recipient = ENV["LITESTREAM_AGE_RECIPIENT"] = nil
+    Litestream.age_secret_key = ENV["LITESTREAM_AGE_SECRET_KEY"] = nil
     Litestream.config_path = nil
   end
 
@@ -130,10 +132,40 @@ class TestCommands < ActiveSupport::TestCase
       assert_equal "access", ENV["LITESTREAM_SECRET_ACCESS_KEY"]
     end
 
+    def test_replicate_sets_age_recipient_env_var_from_config_when_env_var_not_set
+      Litestream.age_recipient = "age1recipient"
+
+      Litestream::Commands.stub :run_replicate, nil do
+        Litestream::Commands.replicate
+      end
+
+      assert_nil ENV["LITESTREAM_REPLICA_BUCKET"]
+      assert_nil ENV["LITESTREAM_ACCESS_KEY_ID"]
+      assert_nil ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_equal "age1recipient", ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_nil ENV["LITESTREAM_AGE_SECRET_KEY"]
+    end
+
+    def test_replicate_sets_age_secret_key_env_var_from_config_when_env_var_not_set
+      Litestream.age_secret_key = "AGE-SECRET-KEY-1SECRET"
+
+      Litestream::Commands.stub :run_replicate, nil do
+        Litestream::Commands.replicate
+      end
+
+      assert_nil ENV["LITESTREAM_REPLICA_BUCKET"]
+      assert_nil ENV["LITESTREAM_ACCESS_KEY_ID"]
+      assert_nil ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_nil ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_equal "AGE-SECRET-KEY-1SECRET", ENV["LITESTREAM_AGE_SECRET_KEY"]
+    end
+
     def test_replicate_sets_all_env_vars_from_config_when_env_vars_not_set
       Litestream.replica_bucket = "mybkt"
       Litestream.replica_key_id = "mykey"
       Litestream.replica_access_key = "access"
+      Litestream.age_recipient = "age1recipient"
+      Litestream.age_secret_key = "AGE-SECRET-KEY-1SECRET"
 
       Litestream::Commands.stub :run_replicate, nil do
         Litestream::Commands.replicate
@@ -142,16 +174,22 @@ class TestCommands < ActiveSupport::TestCase
       assert_equal "mybkt", ENV["LITESTREAM_REPLICA_BUCKET"]
       assert_equal "mykey", ENV["LITESTREAM_ACCESS_KEY_ID"]
       assert_equal "access", ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_equal "age1recipient", ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_equal "AGE-SECRET-KEY-1SECRET", ENV["LITESTREAM_AGE_SECRET_KEY"]
     end
 
     def test_replicate_does_not_set_env_var_from_config_when_env_vars_already_set
       ENV["LITESTREAM_REPLICA_BUCKET"] = "original_bkt"
       ENV["LITESTREAM_ACCESS_KEY_ID"] = "original_key"
       ENV["LITESTREAM_SECRET_ACCESS_KEY"] = "original_access"
+      ENV["LITESTREAM_AGE_RECIPIENT"] = "original_age_recipient"
+      ENV["LITESTREAM_AGE_SECRET_KEY"] = "original_age_secret"
 
       Litestream.replica_bucket = "mybkt"
       Litestream.replica_key_id = "mykey"
       Litestream.replica_access_key = "access"
+      Litestream.age_recipient = "age1recipient"
+      Litestream.age_secret_key = "AGE-SECRET-KEY-1SECRET"
 
       Litestream::Commands.stub :run_replicate, nil do
         Litestream::Commands.replicate
@@ -160,6 +198,8 @@ class TestCommands < ActiveSupport::TestCase
       assert_equal "original_bkt", ENV["LITESTREAM_REPLICA_BUCKET"]
       assert_equal "original_key", ENV["LITESTREAM_ACCESS_KEY_ID"]
       assert_equal "original_access", ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_equal "original_age_recipient", ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_equal "original_age_secret", ENV["LITESTREAM_AGE_SECRET_KEY"]
     end
   end
 
@@ -263,10 +303,40 @@ class TestCommands < ActiveSupport::TestCase
       assert_equal "access", ENV["LITESTREAM_SECRET_ACCESS_KEY"]
     end
 
+    def test_restore_sets_age_recipient_env_var_from_config_when_env_var_not_set
+      Litestream.age_recipient = "age1recipient"
+
+      Litestream::Commands.stub :run, nil do
+        Litestream::Commands.restore("db/test.sqlite3")
+      end
+
+      assert_nil ENV["LITESTREAM_REPLICA_BUCKET"]
+      assert_nil ENV["LITESTREAM_ACCESS_KEY_ID"]
+      assert_nil ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_equal "age1recipient", ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_nil ENV["LITESTREAM_AGE_SECRET_KEY"]
+    end
+
+    def test_restore_sets_age_secret_key_env_var_from_config_when_env_var_not_set
+      Litestream.age_secret_key = "AGE-SECRET-KEY-1SECRET"
+
+      Litestream::Commands.stub :run, nil do
+        Litestream::Commands.restore("db/test.sqlite3")
+      end
+
+      assert_nil ENV["LITESTREAM_REPLICA_BUCKET"]
+      assert_nil ENV["LITESTREAM_ACCESS_KEY_ID"]
+      assert_nil ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_nil ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_equal "AGE-SECRET-KEY-1SECRET", ENV["LITESTREAM_AGE_SECRET_KEY"]
+    end
+
     def test_restore_sets_all_env_vars_from_config_when_env_vars_not_set
       Litestream.replica_bucket = "mybkt"
       Litestream.replica_key_id = "mykey"
       Litestream.replica_access_key = "access"
+      Litestream.age_recipient = "age1recipient"
+      Litestream.age_secret_key = "AGE-SECRET-KEY-1SECRET"
 
       Litestream::Commands.stub :run, nil do
         Litestream::Commands.restore("db/test.sqlite3")
@@ -275,16 +345,22 @@ class TestCommands < ActiveSupport::TestCase
       assert_equal "mybkt", ENV["LITESTREAM_REPLICA_BUCKET"]
       assert_equal "mykey", ENV["LITESTREAM_ACCESS_KEY_ID"]
       assert_equal "access", ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_equal "age1recipient", ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_equal "AGE-SECRET-KEY-1SECRET", ENV["LITESTREAM_AGE_SECRET_KEY"]
     end
 
     def test_restore_does_not_set_env_var_from_config_when_env_vars_already_set
       ENV["LITESTREAM_REPLICA_BUCKET"] = "original_bkt"
       ENV["LITESTREAM_ACCESS_KEY_ID"] = "original_key"
       ENV["LITESTREAM_SECRET_ACCESS_KEY"] = "original_access"
+      ENV["LITESTREAM_AGE_RECIPIENT"] = "original_age_recipient"
+      ENV["LITESTREAM_AGE_SECRET_KEY"] = "original_age_secret"
 
       Litestream.replica_bucket = "mybkt"
       Litestream.replica_key_id = "mykey"
       Litestream.replica_access_key = "access"
+      Litestream.age_recipient = "age1recipient"
+      Litestream.age_secret_key = "AGE-SECRET-KEY-1SECRET"
 
       Litestream::Commands.stub :run, nil do
         Litestream::Commands.restore("db/test.sqlite3")
@@ -293,6 +369,8 @@ class TestCommands < ActiveSupport::TestCase
       assert_equal "original_bkt", ENV["LITESTREAM_REPLICA_BUCKET"]
       assert_equal "original_key", ENV["LITESTREAM_ACCESS_KEY_ID"]
       assert_equal "original_access", ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_equal "original_age_recipient", ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_equal "original_age_secret", ENV["LITESTREAM_AGE_SECRET_KEY"]
     end
   end
 
@@ -392,10 +470,40 @@ class TestCommands < ActiveSupport::TestCase
       assert_equal "access", ENV["LITESTREAM_SECRET_ACCESS_KEY"]
     end
 
+    def test_databases_sets_age_recipient_env_var_from_config_when_env_var_not_set
+      Litestream.age_recipient = "age1recipient"
+
+      Litestream::Commands.stub :run, nil do
+        Litestream::Commands.databases
+      end
+
+      assert_nil ENV["LITESTREAM_REPLICA_BUCKET"]
+      assert_nil ENV["LITESTREAM_ACCESS_KEY_ID"]
+      assert_nil ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_equal "age1recipient", ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_nil ENV["LITESTREAM_AGE_SECRET_KEY"]
+    end
+
+    def test_databases_sets_age_secret_key_env_var_from_config_when_env_var_not_set
+      Litestream.age_secret_key = "AGE-SECRET-KEY-1SECRET"
+
+      Litestream::Commands.stub :run, nil do
+        Litestream::Commands.databases
+      end
+
+      assert_nil ENV["LITESTREAM_REPLICA_BUCKET"]
+      assert_nil ENV["LITESTREAM_ACCESS_KEY_ID"]
+      assert_nil ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_nil ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_equal "AGE-SECRET-KEY-1SECRET", ENV["LITESTREAM_AGE_SECRET_KEY"]
+    end
+
     def test_databases_sets_all_env_vars_from_config_when_env_vars_not_set
       Litestream.replica_bucket = "mybkt"
       Litestream.replica_key_id = "mykey"
       Litestream.replica_access_key = "access"
+      Litestream.age_recipient = "age1recipient"
+      Litestream.age_secret_key = "AGE-SECRET-KEY-1SECRET"
 
       Litestream::Commands.stub :run, nil do
         Litestream::Commands.databases
@@ -404,16 +512,22 @@ class TestCommands < ActiveSupport::TestCase
       assert_equal "mybkt", ENV["LITESTREAM_REPLICA_BUCKET"]
       assert_equal "mykey", ENV["LITESTREAM_ACCESS_KEY_ID"]
       assert_equal "access", ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_equal "age1recipient", ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_equal "AGE-SECRET-KEY-1SECRET", ENV["LITESTREAM_AGE_SECRET_KEY"]
     end
 
     def test_databases_does_not_set_env_var_from_config_when_env_vars_already_set
       ENV["LITESTREAM_REPLICA_BUCKET"] = "original_bkt"
       ENV["LITESTREAM_ACCESS_KEY_ID"] = "original_key"
       ENV["LITESTREAM_SECRET_ACCESS_KEY"] = "original_access"
+      ENV["LITESTREAM_AGE_RECIPIENT"] = "original_age_recipient"
+      ENV["LITESTREAM_AGE_SECRET_KEY"] = "original_age_secret"
 
       Litestream.replica_bucket = "mybkt"
       Litestream.replica_key_id = "mykey"
       Litestream.replica_access_key = "access"
+      Litestream.age_recipient = "age1recipient"
+      Litestream.age_secret_key = "AGE-SECRET-KEY-1SECRET"
 
       Litestream::Commands.stub :run, nil do
         Litestream::Commands.databases
@@ -422,6 +536,8 @@ class TestCommands < ActiveSupport::TestCase
       assert_equal "original_bkt", ENV["LITESTREAM_REPLICA_BUCKET"]
       assert_equal "original_key", ENV["LITESTREAM_ACCESS_KEY_ID"]
       assert_equal "original_access", ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_equal "original_age_recipient", ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_equal "original_age_secret", ENV["LITESTREAM_AGE_SECRET_KEY"]
     end
 
     def test_databases_read_from_custom_configured_litestream_config_path
@@ -541,10 +657,40 @@ class TestCommands < ActiveSupport::TestCase
       assert_equal "access", ENV["LITESTREAM_SECRET_ACCESS_KEY"]
     end
 
+    def test_generations_sets_age_recipient_env_var_from_config_when_env_var_not_set
+      Litestream.age_recipient = "age1recipient"
+
+      Litestream::Commands.stub :run, nil do
+        Litestream::Commands.generations("db/test.sqlite3")
+      end
+
+      assert_nil ENV["LITESTREAM_REPLICA_BUCKET"]
+      assert_nil ENV["LITESTREAM_ACCESS_KEY_ID"]
+      assert_nil ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_equal "age1recipient", ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_nil ENV["LITESTREAM_AGE_SECRET_KEY"]
+    end
+
+    def test_generations_sets_age_secret_key_env_var_from_config_when_env_var_not_set
+      Litestream.age_secret_key = "AGE-SECRET-KEY-1SECRET"
+
+      Litestream::Commands.stub :run, nil do
+        Litestream::Commands.generations("db/test.sqlite3")
+      end
+
+      assert_nil ENV["LITESTREAM_REPLICA_BUCKET"]
+      assert_nil ENV["LITESTREAM_ACCESS_KEY_ID"]
+      assert_nil ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_nil ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_equal "AGE-SECRET-KEY-1SECRET", ENV["LITESTREAM_AGE_SECRET_KEY"]
+    end
+
     def test_generations_sets_all_env_vars_from_config_when_env_vars_not_set
       Litestream.replica_bucket = "mybkt"
       Litestream.replica_key_id = "mykey"
       Litestream.replica_access_key = "access"
+      Litestream.age_recipient = "age1recipient"
+      Litestream.age_secret_key = "AGE-SECRET-KEY-1SECRET"
 
       Litestream::Commands.stub :run, nil do
         Litestream::Commands.generations("db/test.sqlite3")
@@ -553,16 +699,22 @@ class TestCommands < ActiveSupport::TestCase
       assert_equal "mybkt", ENV["LITESTREAM_REPLICA_BUCKET"]
       assert_equal "mykey", ENV["LITESTREAM_ACCESS_KEY_ID"]
       assert_equal "access", ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_equal "age1recipient", ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_equal "AGE-SECRET-KEY-1SECRET", ENV["LITESTREAM_AGE_SECRET_KEY"]
     end
 
     def test_generations_does_not_set_env_var_from_config_when_env_vars_already_set
       ENV["LITESTREAM_REPLICA_BUCKET"] = "original_bkt"
       ENV["LITESTREAM_ACCESS_KEY_ID"] = "original_key"
       ENV["LITESTREAM_SECRET_ACCESS_KEY"] = "original_access"
+      ENV["LITESTREAM_AGE_RECIPIENT"] = "original_age_recipient"
+      ENV["LITESTREAM_AGE_SECRET_KEY"] = "original_age_secret"
 
       Litestream.replica_bucket = "mybkt"
       Litestream.replica_key_id = "mykey"
       Litestream.replica_access_key = "access"
+      Litestream.age_recipient = "age1recipient"
+      Litestream.age_secret_key = "AGE-SECRET-KEY-1SECRET"
 
       Litestream::Commands.stub :run, nil do
         Litestream::Commands.generations("db/test.sqlite3")
@@ -571,6 +723,8 @@ class TestCommands < ActiveSupport::TestCase
       assert_equal "original_bkt", ENV["LITESTREAM_REPLICA_BUCKET"]
       assert_equal "original_key", ENV["LITESTREAM_ACCESS_KEY_ID"]
       assert_equal "original_access", ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_equal "original_age_recipient", ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_equal "original_age_secret", ENV["LITESTREAM_AGE_SECRET_KEY"]
     end
   end
 
@@ -674,10 +828,40 @@ class TestCommands < ActiveSupport::TestCase
       assert_equal "access", ENV["LITESTREAM_SECRET_ACCESS_KEY"]
     end
 
+    def test_snapshots_sets_age_recipient_env_var_from_config_when_env_var_not_set
+      Litestream.age_recipient = "age1recipient"
+
+      Litestream::Commands.stub :run, nil do
+        Litestream::Commands.snapshots("db/test.sqlite3")
+      end
+
+      assert_nil ENV["LITESTREAM_REPLICA_BUCKET"]
+      assert_nil ENV["LITESTREAM_ACCESS_KEY_ID"]
+      assert_nil ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_equal "age1recipient", ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_nil ENV["LITESTREAM_AGE_SECRET_KEY"]
+    end
+
+    def test_snapshots_sets_age_secret_key_env_var_from_config_when_env_var_not_set
+      Litestream.age_secret_key = "AGE-SECRET-KEY-1SECRET"
+
+      Litestream::Commands.stub :run, nil do
+        Litestream::Commands.snapshots("db/test.sqlite3")
+      end
+
+      assert_nil ENV["LITESTREAM_REPLICA_BUCKET"]
+      assert_nil ENV["LITESTREAM_ACCESS_KEY_ID"]
+      assert_nil ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_nil ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_equal "AGE-SECRET-KEY-1SECRET", ENV["LITESTREAM_AGE_SECRET_KEY"]
+    end
+
     def test_snapshots_sets_all_env_vars_from_config_when_env_vars_not_set
       Litestream.replica_bucket = "mybkt"
       Litestream.replica_key_id = "mykey"
       Litestream.replica_access_key = "access"
+      Litestream.age_recipient = "age1recipient"
+      Litestream.age_secret_key = "AGE-SECRET-KEY-1SECRET"
 
       Litestream::Commands.stub :run, nil do
         Litestream::Commands.snapshots("db/test.sqlite3")
@@ -686,16 +870,22 @@ class TestCommands < ActiveSupport::TestCase
       assert_equal "mybkt", ENV["LITESTREAM_REPLICA_BUCKET"]
       assert_equal "mykey", ENV["LITESTREAM_ACCESS_KEY_ID"]
       assert_equal "access", ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_equal "age1recipient", ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_equal "AGE-SECRET-KEY-1SECRET", ENV["LITESTREAM_AGE_SECRET_KEY"]
     end
 
     def test_snapshots_does_not_set_env_var_from_config_when_env_vars_already_set
       ENV["LITESTREAM_REPLICA_BUCKET"] = "original_bkt"
       ENV["LITESTREAM_ACCESS_KEY_ID"] = "original_key"
       ENV["LITESTREAM_SECRET_ACCESS_KEY"] = "original_access"
+      ENV["LITESTREAM_AGE_RECIPIENT"] = "original_age_recipient"
+      ENV["LITESTREAM_AGE_SECRET_KEY"] = "original_age_secret"
 
       Litestream.replica_bucket = "mybkt"
       Litestream.replica_key_id = "mykey"
       Litestream.replica_access_key = "access"
+      Litestream.age_recipient = "age1recipient"
+      Litestream.age_secret_key = "AGE-SECRET-KEY-1SECRET"
 
       Litestream::Commands.stub :run, nil do
         Litestream::Commands.snapshots("db/test.sqlite3")
@@ -704,6 +894,8 @@ class TestCommands < ActiveSupport::TestCase
       assert_equal "original_bkt", ENV["LITESTREAM_REPLICA_BUCKET"]
       assert_equal "original_key", ENV["LITESTREAM_ACCESS_KEY_ID"]
       assert_equal "original_access", ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_equal "original_age_recipient", ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_equal "original_age_secret", ENV["LITESTREAM_AGE_SECRET_KEY"]
     end
   end
 
@@ -807,10 +999,40 @@ class TestCommands < ActiveSupport::TestCase
       assert_equal "access", ENV["LITESTREAM_SECRET_ACCESS_KEY"]
     end
 
+    def test_wal_sets_age_recipient_env_var_from_config_when_env_var_not_set
+      Litestream.age_recipient = "age1recipient"
+
+      Litestream::Commands.stub :run, nil do
+        Litestream::Commands.wal("db/test.sqlite3")
+      end
+
+      assert_nil ENV["LITESTREAM_REPLICA_BUCKET"]
+      assert_nil ENV["LITESTREAM_ACCESS_KEY_ID"]
+      assert_nil ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_equal "age1recipient", ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_nil ENV["LITESTREAM_AGE_SECRET_KEY"]
+    end
+
+    def test_wal_sets_age_secret_key_env_var_from_config_when_env_var_not_set
+      Litestream.age_secret_key = "AGE-SECRET-KEY-1SECRET"
+
+      Litestream::Commands.stub :run, nil do
+        Litestream::Commands.wal("db/test.sqlite3")
+      end
+
+      assert_nil ENV["LITESTREAM_REPLICA_BUCKET"]
+      assert_nil ENV["LITESTREAM_ACCESS_KEY_ID"]
+      assert_nil ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_nil ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_equal "AGE-SECRET-KEY-1SECRET", ENV["LITESTREAM_AGE_SECRET_KEY"]
+    end
+
     def test_wal_sets_all_env_vars_from_config_when_env_vars_not_set
       Litestream.replica_bucket = "mybkt"
       Litestream.replica_key_id = "mykey"
       Litestream.replica_access_key = "access"
+      Litestream.age_recipient = "age1recipient"
+      Litestream.age_secret_key = "AGE-SECRET-KEY-1SECRET"
 
       Litestream::Commands.stub :run, nil do
         Litestream::Commands.wal("db/test.sqlite3")
@@ -819,16 +1041,22 @@ class TestCommands < ActiveSupport::TestCase
       assert_equal "mybkt", ENV["LITESTREAM_REPLICA_BUCKET"]
       assert_equal "mykey", ENV["LITESTREAM_ACCESS_KEY_ID"]
       assert_equal "access", ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_equal "age1recipient", ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_equal "AGE-SECRET-KEY-1SECRET", ENV["LITESTREAM_AGE_SECRET_KEY"]
     end
 
     def test_wal_does_not_set_env_var_from_config_when_env_vars_already_set
       ENV["LITESTREAM_REPLICA_BUCKET"] = "original_bkt"
       ENV["LITESTREAM_ACCESS_KEY_ID"] = "original_key"
       ENV["LITESTREAM_SECRET_ACCESS_KEY"] = "original_access"
+      ENV["LITESTREAM_AGE_RECIPIENT"] = "original_age_recipient"
+      ENV["LITESTREAM_AGE_SECRET_KEY"] = "original_age_secret"
 
       Litestream.replica_bucket = "mybkt"
       Litestream.replica_key_id = "mykey"
       Litestream.replica_access_key = "access"
+      Litestream.age_recipient = "age1recipient"
+      Litestream.age_secret_key = "AGE-SECRET-KEY-1SECRET"
 
       Litestream::Commands.stub :run, nil do
         Litestream::Commands.wal("db/test.sqlite3")
@@ -837,6 +1065,8 @@ class TestCommands < ActiveSupport::TestCase
       assert_equal "original_bkt", ENV["LITESTREAM_REPLICA_BUCKET"]
       assert_equal "original_key", ENV["LITESTREAM_ACCESS_KEY_ID"]
       assert_equal "original_access", ENV["LITESTREAM_SECRET_ACCESS_KEY"]
+      assert_equal "original_age_recipient", ENV["LITESTREAM_AGE_RECIPIENT"]
+      assert_equal "original_age_secret", ENV["LITESTREAM_AGE_SECRET_KEY"]
     end
   end
 

--- a/test/tasks/test_litestream_tasks.rb
+++ b/test/tasks/test_litestream_tasks.rb
@@ -30,6 +30,8 @@ class TestLitestreamTasks < ActiveSupport::TestCase
         LITESTREAM_REPLICA_ENDPOINT=
         LITESTREAM_ACCESS_KEY_ID=
         LITESTREAM_SECRET_ACCESS_KEY=
+        LITESTREAM_AGE_RECIPIENT=
+        LITESTREAM_AGE_SECRET_KEY=
       TXT
     end
   end


### PR DESCRIPTION
  ## Summary

  Adds support for [age encryption](https://github.com/FiloSottile/age) to encrypt Litestream database backups at rest. This introduces two new configuration options:
  `age_recipient` (public key) and `age_secret_key` (identity/private key).

  ## Changes

  ### Core Configuration
  - Added `age_recipient` and `age_secret_key` to `Litestream::Configuration`
  - Added module-level accessors matching the pattern of other replica configuration options
  - Environment variables `LITESTREAM_AGE_RECIPIENT` and `LITESTREAM_AGE_SECRET_KEY` are now set in the `prepare` method for all commands

  ### Rake Tasks
  - Updated `litestream:env` task to output the new age encryption variables

  ### Generator Templates
  - **Config template**: Added commented `age:` section with `recipients:` and `identities:` fields following the [Litestream age encryption format](https://litestream.io/reference/config/#encryption)
  - **Initializer template**: Added documentation for configuring age encryption credentials via Rails encrypted credentials

  ### Testing
  - Updated teardown to clear age environment variables
  - Added individual tests for `age_recipient` and `age_secret_key` for all commands (replicate, restore, databases, generations, snapshots, wal)
  - Updated comprehensive tests to verify age variables are set alongside other replica configuration
  - Updated `litestream:env` task test expectations

  ## Usage

  Users can configure age encryption in their `config/initializers/litestream.rb`:

  ```ruby
  Rails.application.configure do
    config.litestream.age_recipient = Rails.application.credentials.litestream&.age_recipient
    config.litestream.age_secret_key = Rails.application.credentials.litestream&.age_secret_key
  end

  Then uncomment the age: section in config/litestream.yml:

  age:
    recipients:
      - $LITESTREAM_AGE_RECIPIENT
    identities:
      - $LITESTREAM_AGE_SECRET_KEY

  The environment variables will be automatically set when running Litestream commands through the gem.