### PR TITLE
Set engine layout on ApplicationController

### DIFF
--- a/app/controllers/litestream/application_controller.rb
+++ b/app/controllers/litestream/application_controller.rb
@@ -1,5 +1,7 @@
 module Litestream
   class ApplicationController < Litestream.base_controller_class.constantize
+    layout "litestream/application"
+
     protect_from_forgery with: :exception
 
     if Litestream.password

--- a/test/controllers/test_processes_controller.rb
+++ b/test/controllers/test_processes_controller.rb
@@ -21,6 +21,7 @@ class Litestream::TestProcessesController < ActionDispatch::IntegrationTest
       Litestream.stub :databases, stubbed_databases do
         get litestream.process_url
         assert_response :success
+        assert_select "title", "Litestream"
 
         assert_select "#process_12345", 1 do
           assert_select "small", "sleeping"

--- a/test/dummy/app/controllers/my_application_controller.rb
+++ b/test/dummy/app/controllers/my_application_controller.rb
@@ -1,2 +1,3 @@
 class MyApplicationController < ApplicationController
+  layout "application"
 end

--- a/test/litestream/test_base_application_controller.rb
+++ b/test/litestream/test_base_application_controller.rb
@@ -8,4 +8,8 @@ class Litestream::BaseApplicationControllerTest < ActiveSupport::TestCase
   test "engine's ApplicationController inherits from configured base_controller_class" do
     assert Litestream::ApplicationController < MyApplicationController
   end
+
+  test "engine's ApplicationController uses its own layout regardless of base controller layout" do
+    assert_equal "litestream/application", Litestream::ApplicationController._layout
+  end
 end


### PR DESCRIPTION
## Problem

When `base_controller_class` is configured to a controller that declares its own layout (e.g. `layout "admin"`), `Litestream::ApplicationController` inherits that layout. Since the host app's layout uses route helpers that aren't available inside a mounted engine, this causes a `NameError`:

```
NameError: undefined local variable or method 'some_host_app_path'
  from app/views/layouts/admin.html.erb:1
```

## Root cause

`Litestream::ApplicationController` doesn't declare its own layout. The `litestream/application` layout file exists, but without an explicit `layout` declaration on the controller, Rails resolves the layout from the parent class.

## Fix

Add `layout "litestream/application"` to `Litestream::ApplicationController`. This matches what other Rails engine dashboards do:

- `mission_control-jobs`: `layout "mission_control/jobs/application"`
- `audits1984`: `layout "audits1984/application"`
- `blazer`: `layout "blazer/application"`

## Tests

- Unit test: asserts the controller's layout is `litestream/application` regardless of the base controller's layout
- Integration test: asserts the rendered page uses the engine's `<title>Litestream</title>`, not the host app's
- The dummy app's `MyApplicationController` now sets `layout "application"` to exercise this scenario