### PR TITLE
Add busy_timeout to verify! method to gracefully handle concurrent write locks

### DIFF
--- a/lib/litestream.rb
+++ b/lib/litestream.rb
@@ -37,8 +37,10 @@ module Litestream
   mattr_accessor :base_controller_class, default: "::ApplicationController"
 
   class << self
-    def verify!(database_path, replication_sleep: 10)
+    def verify!(database_path, replication_sleep: 10, busy_timeout: 5000)
       database = SQLite3::Database.new(database_path)
+      # Apply the busy_timeout to handle concurrent write locks gracefully
+      database.busy_timeout = busy_timeout
       database.execute("CREATE TABLE IF NOT EXISTS _litestream_verification (id INTEGER PRIMARY KEY, uuid BLOB)")
       sentinel = SecureRandom.uuid
       database.execute("INSERT INTO _litestream_verification (uuid) VALUES (?)", [sentinel])
@@ -49,6 +51,7 @@ module Litestream
       Litestream::Commands.restore(database_path, **{"-o" => backup_path})
 
       backup = SQLite3::Database.new(backup_path)
+      backup.busy_timeout = busy_timeout
       result = backup.execute("SELECT 1 FROM _litestream_verification WHERE uuid = ? LIMIT 1", sentinel) # => [[1]] || []
 
       raise VerificationFailure, "Verification failed for `#{database_path}`" if result.empty?


### PR DESCRIPTION
The Litestream.verify! method opens a direct SQLite3::Database connection to insert a sentinel value and confirm replication. However, because this connection is created outside of Active Record's connection pool, it does not inherit the timeout configuration defined in database.yml.

In production environments with active, concurrent write load, the verification task's sentinel write can hit a momentary lock collision and immediately raise SQLite3::BusyException, causing the verification job to fail.

This PR adds a busy_timeout keyword argument (defaulting to 5000ms) to verify! and applies it to the raw connection before executing schema creation or inserts. This aligns the method's concurrency behaviour with standard Rails SQLite configurations and prevents false-positive job failures.

**Changes:**

- Added busy_timeout: 5000 keyword argument to Litestream.verify!.
- Configured database.busy_timeout = busy_timeout on the raw SQLite3::Database instance.